### PR TITLE
Setting up cron job for hourly updates

### DIFF
--- a/src/cron_script.sh
+++ b/src/cron_script.sh
@@ -1,8 +1,40 @@
 #!/bin/bash
 
-# shellcheck disable=SC2164
-pushd "${HOME}"/Imperative/src
-#touch "testing$(date +%H%M%S)"
-popd
+# Define variables
+PROJECT_BASE="${HOME}/Imperative"
+PROJECT_DIR="${PROJECT_BASE}/src"
+SERVER_LOG="${PROJECT_BASE}/server.log"
+
+
+# Function to kill the running server
+kill_server() {
+  # Find the process ID of the server
+  SERVER_PID=$(pgrep -f "exec:java@server")
+  if [ -n "$SERVER_PID" ]; then
+    echo "Killing server with PID: $SERVER_PID"
+    kill -9 "$SERVER_PID"
+  else
+    echo "No running server found"
+  fi
+}
+
+# Change to the project directory
+pushd "$PROJECT_DIR" || exit
+
+# Kill the currently running server
+kill_server
+
+# Pull the latest code from the master branch
+git fetch
+git pull origin master
+
+# Build the project using Maven
+./mvnw clean compile
+
+# Start the updated server
+./mvnw exec:java@server
+
+# Return to the previous directory
+popd || exit
 
 #crontab is 0 * * * * /bin/sh ${HOME}/Imperative/src/cron_script.sh for hourly updates

--- a/src/cron_script.sh
+++ b/src/cron_script.sh
@@ -3,6 +3,7 @@
 # Define variables
 PROJECT_BASE="${HOME}/Imperative"
 PROJECT_DIR="${PROJECT_BASE}/src"
+SERVER_START_CMD="./mvnw exec:java@server" # Command to start your server
 SERVER_LOG="${PROJECT_BASE}/server.log"
 
 
@@ -31,10 +32,14 @@ git pull origin master
 # Build the project using Maven
 ./mvnw clean compile
 
-# Start the updated server
-./mvnw exec:java@server
+#Start the updated server and log output to server.log, the server will be started but backgrounded and running in a separate thread
+nohup $SERVER_START_CMD > "$SERVER_LOG" 2>&1 &
 
 # Return to the previous directory
 popd || exit
 
-#crontab is 0 * * * * /bin/sh ${HOME}/Imperative/src/cron_script.sh for hourly updates
+#CRONTAB INSTRUCTIONS
+# on the lab machine, in a terminal use crontab -e
+# this will open in vim where you need to enter this line
+# 0 * * * * /bin/sh ${HOME}/Imperative/src/cron_script.sh
+# this will update every hour calling the cron script above

--- a/src/cron_script.sh
+++ b/src/cron_script.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# shellcheck disable=SC2164
+pushd "${HOME}"/Imperative/src
+#touch "testing$(date +%H%M%S)"
+popd
+
+#crontab is 0 * * * * /bin/sh ${HOME}/Imperative/src/cron_script.sh for hourly updates


### PR DESCRIPTION
The cron-tab calls every hour the cron script that kills the currently running server, pulls the latest version from main, builds the project using Maven and then runs the updated version of the STAG server